### PR TITLE
Overhaul for 3.0

### DIFF
--- a/classes/pmpror4c-class-member-edit-panel-reasons.php
+++ b/classes/pmpror4c-class-member-edit-panel-reasons.php
@@ -1,0 +1,78 @@
+<?php
+
+class PMPror4c_Member_Edit_Panel_Reasons extends PMPro_Member_Edit_Panel {
+	/**
+	 * Set up the panel.
+	 */
+	public function __construct() {
+		$this->slug = 'pmpror4c-reasons';
+		$this->title = __( 'Cancellation Reasons', 'pmpro-reason-for-cancelling' );
+	}
+
+	/**
+	 * Display the panel contents.
+	 */
+	protected function display_panel_contents() {
+		// Get the user being edited.
+		$user = self::get_user();
+
+		// Get all reasons for this user.
+		$reasons = get_user_meta( $user->ID, 'pmpror4c_reason', false );
+
+		// If there are no reasons, display a message and return.
+		if ( empty( $reasons ) ) {
+			?>
+			<p><?php esc_html_e( 'This user has not submitted any reasons for cancelling.', 'pmpro-reason-for-cancelling' ); ?></p>
+			<?php
+			return;
+		}
+
+		// Order reasons by timestamp in descending order.
+		usort( $reasons, function( $a, $b ) {
+			return $b['timestamp'] - $a['timestamp'];
+		} );
+
+		// Display the reasons in a table.
+		?>
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Date', 'pmpro-reason-for-cancelling' ); ?></th>
+					<th><?php esc_html_e( 'Cancelled Level(s)', 'pmpro-reason-for-cancelling' ); ?></th>
+					<th><?php esc_html_e( 'Reason', 'pmpro-reason-for-cancelling' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php
+				foreach ( $reasons as $reason ) {
+					?>
+					<tr>
+						<td><?php echo esc_html( date_i18n( get_option( 'date_format' ), $reason['timestamp'] ) ); ?></td>
+						<td>
+							<?php
+							// $reason['levels'] will be 'all' or a string of level IDs separated by '+'.
+							if ( 'all' === $reason['levels'] ) {
+								esc_html_e( 'All Levels', 'pmpro-reason-for-cancelling' );
+							} else {
+								$level_ids = explode( '+', $reason['levels'] );
+								$level_names = array();
+								foreach ( $level_ids as $level_id ) {
+									$level = pmpro_getLevel( $level_id );
+									if ( ! empty( $level ) ) {
+										$level_names[] = $level->name;
+									}
+								}
+								esc_html_e( implode( ', ', $level_names ) );
+							}
+							?>
+						</td>
+						<td><?php echo esc_html( $reason['reason'] ); ?></td>
+					</tr>
+					<?php
+				}
+				?>
+			</tbody>
+		</table>
+		<?php
+	}
+}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -8,7 +8,7 @@ function pmpror4c_pages_custom_template_path( $templates, $page_name ) {
 		return $templates;
 	}
 
-	$templates[] = plugin_dir_path(__FILE__) . 'templates/' . $page_name . '.php';	
+	$templates[] = plugin_dir_path(__FILE__) . '../templates/' . $page_name . '.php';	
 
 	return $templates;
 }

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,75 @@
+<?php
+// Legacy code for before PMPro v3.0.
+
+// use our cancel template
+function pmpror4c_pages_custom_template_path( $templates, $page_name ) {
+	// Bail if using PMPro v3.0 or later.
+	if ( class_exists( 'PMPro_Subscription') ) {
+		return $templates;
+	}
+
+	$templates[] = plugin_dir_path(__FILE__) . 'templates/' . $page_name . '.php';	
+
+	return $templates;
+}
+add_filter( 'pmpro_pages_custom_template_path', 'pmpror4c_pages_custom_template_path', 10, 2 );
+
+// make sure they enter a reason
+function pmpror4c_init() {
+	// Bail if using PMPro v3.0 or later.
+	if ( class_exists( 'PMPro_Subscription') ) {
+		return;
+	}
+
+	if ( ! empty( $_REQUEST['confirm'] ) && ! empty( $_REQUEST['membership_cancel'] ) && empty( $_REQUEST['reason'] ) ) {
+		global $pmpro_msg, $pmpro_msgt;
+		$_REQUEST['confirm'] = null;
+		$pmpro_msg = __( 'Please enter a reason for cancelling.', 'pmpro-reason-for-cancelling' );
+		$pmpro_msgt = 'pmpro_error';
+	}
+}
+add_action( 'init', 'pmpror4c_init' );
+
+// Save the reason to the last order.
+function pmpror4c_save_reason_to_last_order( $level_id, $user_id, $cancel_level ) {
+	// Bail if using PMPro v3.0 or later.
+	if ( class_exists( 'PMPro_Subscription') ) {
+		return;
+	}
+
+	if ( ! empty( $_REQUEST['reason'] ) && $level_id === 0 ) {
+		$reason = wp_unslash( sanitize_text_field( $_REQUEST['reason'] ) );
+
+		$order = new MemberOrder();
+		if ( $order->getlastMemberOrder( $user_id, array("", "success", "cancelled"), $cancel_level ) ) {
+			$order->notes .= __( 'Reason for cancelling:', 'pmpro-reason-for-cancelling' ) . ' ' . $reason;
+			$order->saveOrder();
+		}
+	}
+}
+add_action( 'pmpro_after_change_membership_level', 'pmpror4c_save_reason_to_last_order', 10, 3 );
+
+// add reason to cancel email
+function pmpror4c_pmpro_email_body( $body, $email ) {
+	// Bail if using PMPro v3.0 or later.
+	if ( class_exists( 'PMPro_Subscription') ) {
+		return $body;
+	}
+
+	if( !empty( $_REQUEST['reason'] ) ) {
+		$reason = wp_unslash( sanitize_text_field( $_REQUEST['reason'] ) );
+	} else {
+		$reason = __( 'N/A', 'pmpro-reason-for-cancelling' );
+	}
+
+	// replace in standard templates
+	if ( $email->template == 'cancel' || $email->template == 'cancel_admin' ) {
+		$body = str_replace( 'has been cancelled.</p>', 'has been cancelled.</p><p>Reason: ' . $reason . '</p>', $body );
+	}
+
+	// or replace in custom template
+	$body = str_replace( '!!reason!!', $reason, $body );
+
+	return $body;
+}
+add_action( 'pmpro_email_body', 'pmpror4c_pmpro_email_body', 10, 2 );


### PR DESCRIPTION
Has backward compatibility to keep existing functionality for 2.x, but has the following improvements for 3.0:

- No longer needs custom cancel page template, can use hooks built into 3.0
- Saves reasons to user meta instead of order notes
- Adds panel to 3.0 edit member page to see all of a user's cancellation reasons listed in one place

Resolves #16 