### PR TITLE
Update cancellation wording to "What made you cancel?"

### DIFF
--- a/pmpro-reason-for-cancelling.php
+++ b/pmpro-reason-for-cancelling.php
@@ -54,7 +54,11 @@ function pmpror4c_cancel_should_process( $process_cancellation ) {
 	}
 
 	// Make sure a reason is provided.
-	if ( empty( trim( $_REQUEST['pmpro_cancel_reason'] ) ) ) {
+	$reason = '';
+	if ( isset( $_REQUEST['pmpro_cancel_reason'] ) ) {
+		$reason = trim( wp_unslash( sanitize_text_field( $_REQUEST['pmpro_cancel_reason'] ) ) );
+	}
+	if ( empty( $reason ) ) {
 		pmpro_setMessage( __( 'Please tell us what made you cancel.', 'pmpro-reason-for-cancelling' ), 'pmpro_error' );
 		return false;
 	}

--- a/pmpro-reason-for-cancelling.php
+++ b/pmpro-reason-for-cancelling.php
@@ -28,7 +28,7 @@ function pmpror4c_cancel_before_submit() {
 		<div id="pmpro_cancel_reason_div" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-textarea pmpro_form_field-required' ) ); ?>">
 			<label class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>" for="pmpro_cancel_reason">
 				<?php esc_html_e( 'What made you cancel?', 'pmpro-reason-for-cancelling' ); ?>
-				<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_attr_e( 'Required Field' ,'pmpro-reason-for-cancelling' ); ?>">*</abbr></span>
+				<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_attr_e( 'Required Field', 'pmpro-reason-for-cancelling' ); ?>">*</abbr></span>
 			</label>
 			<textarea id="pmpro_cancel_reason" name="pmpro_cancel_reason" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea pmpro_form_field-required' ) ); ?>"></textarea>
 		</div> <!-- end pmpro_cancel_reason_div -->

--- a/pmpro-reason-for-cancelling.php
+++ b/pmpro-reason-for-cancelling.php
@@ -10,8 +10,8 @@
  * Domain Path: /languages
  */
 
- // Load functionality for PMPro v2.x.
- include_once( dirname( __FILE__ ) . '/includes/deprecated.php' );
+// Load functionality for PMPro v2.x.
+include_once( dirname( __FILE__ ) . '/includes/deprecated.php' );
 
 /**
  * Add a reason field to the cancel page.
@@ -22,12 +22,12 @@
  */
 function pmpror4c_cancel_before_submit() {
 	?>
-	<p><?php esc_html_e( 'If so, please enter a reason for cancelling and click the button to confirm cancellation below.', 'pmpro-reason-for-cancelling' ); ?></p>
+	<p><?php esc_html_e( 'What made you cancel? Please share your reason below and click the button to confirm cancellation.', 'pmpro-reason-for-cancelling' ); ?></p>
 	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_divider' ) ); ?>"></div>
 	<div id="pmpro_reason_for_cancelling" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields', 'pmpro_reason_for_cancelling' ) ); ?>">
 		<div id="pmpro_cancel_reason_div" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-textarea pmpro_form_field-required' ) ); ?>">
 			<label class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>" for="pmpro_cancel_reason">
-				<?php esc_html_e( 'Reason for Cancelling', 'pmpro-reason-for-cancelling' ); ?>
+				<?php esc_html_e( 'What made you cancel?', 'pmpro-reason-for-cancelling' ); ?>
 				<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_attr_e( 'Required Field' ,'pmpro-reason-for-cancelling' ); ?>">*</abbr></span>
 			</label>
 			<textarea id="pmpro_cancel_reason" name="pmpro_cancel_reason" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea pmpro_form_field-required' ) ); ?>"></textarea>
@@ -55,7 +55,7 @@ function pmpror4c_cancel_should_process( $process_cancellation ) {
 
 	// Make sure a reason is provided.
 	if ( empty( trim( $_REQUEST['pmpro_cancel_reason'] ) ) ) {
-		pmpro_setMessage( __( 'Please enter a reason for cancelling.', 'pmpro-reason-for-cancelling' ), 'pmpro_error' );
+		pmpro_setMessage( __( 'Please tell us what made you cancel.', 'pmpro-reason-for-cancelling' ), 'pmpro_error' );
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #36
Updates the default cancellation wording as suggested in the issue, changing "Reason for Cancelling" / "Why did you cancel?" style phrasing to "What made you cancel?" across the label, intro text, and validation message.