### PR TITLE
Show "System Cancelled" instead of "N/A"

### DIFF
--- a/pmpro-reason-for-cancelling.php
+++ b/pmpro-reason-for-cancelling.php
@@ -83,7 +83,7 @@ function pmpror4c_email_body( $body, $email ) {
 	if ( ! empty( $_REQUEST['pmpro_cancel_reason'] ) ) {
 		$reason = trim( wp_unslash( sanitize_text_field( $_REQUEST['pmpro_cancel_reason'] ) ) );
 	} else {
-		$reason = __( 'N/A', 'pmpro-reason-for-cancelling' );
+		$reason = __( 'System Cancelled', 'pmpro-reason-for-cancelling' );
 	}
 
 	// Replace in standard templates.


### PR DESCRIPTION
* ENHANCEMENT: Cleared wording around cancellations that may happen outside of the member's control (payment gateway, admin cancellations).

Resolves: https://github.com/strangerstudios/pmpro-reason-for-cancelling/issues/7